### PR TITLE
Fix for issue #3.

### DIFF
--- a/mbientlab/metawear/__init__.py
+++ b/mbientlab/metawear/__init__.py
@@ -152,7 +152,16 @@ class MetaWear(object):
         @params:
             serialize   - Optional  : Serialize and cached C++ SDK state after initializaion, defaults to true
         """
-        self.gatt.connect(True, channel_type='random')
+        try:
+            self.gatt.connect(True, channel_type='random')
+        except RuntimeError as e:
+            # gattlib.connect's `wait=True` requires elevated permission
+            # or modified capabilities.
+            # It still connects, but a RuntimeError is raised. Check if
+            # `self.gatt` is connected, and rethrow exception otherwise.
+            if not self.gatt.is_connected():
+                raise e
+
 
         self.services = set()
         for s in self.gatt.discover_primary():


### PR DESCRIPTION
`gattlib.connect`'s `wait=True` requires elevated permission or modified capabilities.

It still connects, but a `RuntimeError` is raised. This PR checks if `self.gatt` is connected after error is caught, and reraises it otherwise.