### PR TITLE
Fix installation on aarch64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 import platform
 import sys
 
-machine = os.environ['MACHINE'] if 'MACHINE' in os.environ else ("arm" if "arm" in platform.machine() else ("x64" if sys.maxsize > 2**32 else "x86"))
+machine = os.environ['MACHINE'] if 'MACHINE' in os.environ else ("arm" if ("arm" in platform.machine()) or ("aarch64" in platform.machine()) else ("x64" if sys.maxsize > 2**32 else "x86"))
 root = os.path.dirname(os.path.abspath(__file__))
 dest = os.path.join("mbientlab", "metawear")
 


### PR DESCRIPTION
Match C library convention of `machine = "arm"` for aarch64

Fixes #14 