### PR TITLE
Fix typo in `create_voidp` error handler

### DIFF
--- a/mbientlab/metawear/__init__.py
+++ b/mbientlab/metawear/__init__.py
@@ -72,7 +72,7 @@ def create_voidp(fn, **kwargs):
 
     result = [None]
     def handler(ctx, pointer):
-        result[0] = RuntimeError("Could not create " + (kwargs['resource'] if 'resource' in kwarg else "resource") ) if pointer == None else pointer
+        result[0] = RuntimeError("Could not create " + (kwargs['resource'] if 'resource' in kwargs else "resource") ) if pointer == None else pointer
         e.set()
 
     callback_wrapper = FnVoid_VoidP_VoidP(handler)


### PR DESCRIPTION
Not really a major issue, since it's in an error handler, but the variable `kwarg` should be `kwargs`.